### PR TITLE
Prevent cancel button to open details page

### DIFF
--- a/packages/app-imports/src/components/List/Item.tsx
+++ b/packages/app-imports/src/components/List/Item.tsx
@@ -41,7 +41,10 @@ export function Item({ job }: Props): JSX.Element {
         {canDelete ? (
           <Button
             variant='danger'
-            onClick={() => {
+            type='button'
+            onClick={(e) => {
+              e.stopPropagation()
+              e.preventDefault()
               deleteImport(job.id)
             }}
           >


### PR DESCRIPTION
This prevents the click on the cancel button to bubble up and be propagated to the parent `<a href>` tag, causing the opening of the details page instead of deleting the import.
