### PR TITLE
Show error when csv exceed rows limit

### DIFF
--- a/packages/app-imports/src/components/InputParser/index.tsx
+++ b/packages/app-imports/src/components/InputParser/index.tsx
@@ -55,9 +55,16 @@ export const InputParser: FC<Props> = ({
         )
       },
       // eslint-disable-next-line @typescript-eslint/no-misused-promises
-      complete: async ({ data }) => {
+      complete: async ({ data: csvRows }) => {
+        if (csvRows.length > importMaxSize) {
+          setErrorMessage(
+            `Maximum number of records exceeded. You are trying to import ${csvRows.length} records, but limit is ${importMaxSize} per task. Please split your file in smaller chunks.`
+          )
+          setIsParsing(false)
+          return
+        }
+
         const parser = parsers[resourceType]
-        const csvRows = data.slice(0, importMaxSize)
         const parsedResources = isMakeSchemaFn(parser)
           ? parser({ hasParentResource }).safeParse(csvRows)
           : parser.safeParse(csvRows)


### PR DESCRIPTION
## What I did

When user is importing a file that exceeds `10000` records I now show an error message preventing they to create the import, instead of cutting (slicing) the file silently at `10000` items.

<img width="587" alt="image" src="https://github.com/commercelayer/app-imports/assets/30926550/bd8e4c9c-e14f-4d10-9de7-72ffd305d9cd">

In future we can plan to have similar behaviour as the CLI that automatically splits the csv up to 5 imports tasks.

## How to test

1. Open the app
2. Try to upload a file with more that 10K rows
3. You will get a validation error message preventing you to create the import

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [x] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests).
- [x] Make sure to add/update documentation regarding your changes.
- [x] You are **NOT** deprecating/removing a feature.
