### PR TITLE
Make parent resource not mandatory

### DIFF
--- a/packages/app/src/components/ResourceFinder/index.tsx
+++ b/packages/app/src/components/ResourceFinder/index.tsx
@@ -12,7 +12,7 @@ import {
   type InputSelectProps
 } from '@commercelayer/app-elements/dist/ui/forms/InputSelect'
 
-interface Props {
+interface Props extends Pick<InputSelectProps, 'feedback' | 'hint'> {
   /**
    * Text to show above the input
    */
@@ -33,10 +33,6 @@ interface Props {
    * callback function fired when the resource is selected from the list
    */
   onSelect?: (resourceId: string | null) => void
-  /**
-   * Validation feedback
-   */
-  feedback?: InputSelectProps['feedback']
 }
 
 export function ResourceFinder({
@@ -45,6 +41,7 @@ export function ResourceFinder({
   resourceType,
   sdkClient,
   feedback,
+  hint,
   onSelect
 }: Props): JSX.Element {
   const [isLoading, setIsLoading] = useState(true)
@@ -85,6 +82,7 @@ export function ResourceFinder({
         initialValues={initialValues}
         isClearable
         feedback={feedback}
+        hint={hint}
         placeholder={placeholder}
         isLoading={isLoading}
         onSelect={(selected) => {

--- a/packages/app/src/pages/NewImportPage.tsx
+++ b/packages/app/src/pages/NewImportPage.tsx
@@ -36,7 +36,6 @@ function NewImportPage(): JSX.Element {
   )
   const [_location, setLocation] = useLocation()
 
-  const [isTouched, setIsTouched] = useState(false)
   const [isLoading, setIsLoading] = useState(false)
   const [apiError, setApiError] = useState<string | undefined>()
   const [parentResourceId, setParentResourceId] = useState<string | null>()
@@ -128,9 +127,7 @@ function NewImportPage(): JSX.Element {
 
   const parentResource = getParentResourceIfNeeded(resourceType)
   const canCreateImport =
-    importCreateValue != null &&
-    importCreateValue.length > 0 &&
-    (parentResourceId != null || parentResource === false)
+    importCreateValue != null && importCreateValue.length > 0
 
   return (
     <PageLayout
@@ -160,14 +157,9 @@ function NewImportPage(): JSX.Element {
             resourceType={parentResource}
             sdkClient={sdkClient}
             onSelect={setParentResourceId}
-            feedback={
-              parentResourceId == null && isTouched
-                ? {
-                    message: 'Please select a parent resource',
-                    variant: 'danger'
-                  }
-                : undefined
-            }
+            hint={{
+              text: 'Required when creating new records. Can also be specified in the import data, for each single record.'
+            }}
           />
         </Spacer>
       )}
@@ -215,7 +207,6 @@ function NewImportPage(): JSX.Element {
         <Button
           variant='primary'
           onClick={() => {
-            setIsTouched(true)
             if (!canCreateImport) {
               return
             }


### PR DESCRIPTION
## What I did

Since we noticed that the app is used mostly to update existing resources, instead of creating new ones, we decided to set the parent resource field as optional.

<img width="720" alt="image" src="https://github.com/commercelayer/app-imports/assets/30926550/a6eadd26-6b3b-4da0-94c5-12fb628c4be8">


## How to test

<!-- Please include the steps to test your changes here -->

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [ ] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests).
- [ ] Make sure to add/update documentation regarding your changes.
- [ ] You are **NOT** deprecating/removing a feature.
