### PR TITLE
Export 'Main' component as default

### DIFF
--- a/packages/app/src/main.tsx
+++ b/packages/app/src/main.tsx
@@ -3,7 +3,8 @@ import {
   ErrorBoundary,
   MetaTags,
   TokenProvider,
-  createApp
+  createApp,
+  type ClAppProps
 } from '@commercelayer/app-elements'
 import '@commercelayer/app-elements/style.css'
 import { StrictMode } from 'react'
@@ -11,25 +12,26 @@ import { App } from './App'
 
 const isDev = Boolean(import.meta.env.DEV)
 
-createApp(
-  (props) => (
-    <StrictMode>
-      <ErrorBoundary hasContainer>
-        <TokenProvider
-          kind='imports'
-          appSlug='imports'
-          devMode={isDev}
-          reauthenticateOnInvalidAuth={!isDev && props?.onInvalidAuth == null}
-          loadingElement={<div />}
-          {...props}
-        >
-          <CoreSdkProvider>
-            <MetaTags />
-            <App routerBase={props?.routerBase} />
-          </CoreSdkProvider>
-        </TokenProvider>
-      </ErrorBoundary>
-    </StrictMode>
-  ),
-  'imports'
+const Main: React.FC<ClAppProps> = (props) => (
+  <StrictMode>
+    <ErrorBoundary hasContainer>
+      <TokenProvider
+        kind='imports'
+        appSlug='imports'
+        devMode={isDev}
+        reauthenticateOnInvalidAuth={!isDev && props?.onInvalidAuth == null}
+        loadingElement={<div />}
+        {...props}
+      >
+        <CoreSdkProvider>
+          <MetaTags />
+          <App routerBase={props?.routerBase} />
+        </CoreSdkProvider>
+      </TokenProvider>
+    </ErrorBoundary>
+  </StrictMode>
 )
+
+export default Main
+
+createApp(Main, 'imports')


### PR DESCRIPTION
## What I did

I exported the `Main` component as `default`. This is to support future mono-repository.